### PR TITLE
fix: Vercel deployment path resolution issues

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".",
     "plugins": [
       {
         "name": "next"

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,7 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "devCommand": "npm run dev",
+  "installCommand": "npm install",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
- Add vercel.json to explicitly configure build settings
- Add baseUrl to tsconfig.json for better path resolution
- Ensure @/ imports work correctly in Vercel builds
- Verified build works locally with these changes